### PR TITLE
Extend manual forum digest generation command with `broad` option

### DIFF
--- a/notifier/management/commands/forums_digest.py
+++ b/notifier/management/commands/forums_digest.py
@@ -193,7 +193,9 @@ class Command(BaseCommand):
             generate_and_send_digests.delay(
                 some_users,
                 from_datetime,
-                to_datetime)
+                to_datetime,
+                broad=options.get('broad')
+            )
 
         user_batch = []
         for user in users:


### PR DESCRIPTION
Makes it possible to manually send daily digests in new featured `broad mode`.